### PR TITLE
[fix]db에 nickname이 존재하지않을때의 if문추가

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -2,6 +2,7 @@ import { LoginDto } from 'src/dto/login.dto';
 import { SignupDto } from '../dto/signup.dto';
 import { UserService } from './user.service';
 import { Controller, Post, Body } from '@nestjs/common';
+import { Users } from 'src/entities/Users.entity';
 
 @Controller('auth')
 export class UserController {
@@ -10,6 +11,7 @@ export class UserController {
 
   @Post('signup')
   async signup(@Body() singupData: SignupDto) {
+    console.log(singupData, 'dddddddddddd');
     return this.userService.signup(singupData);
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -24,12 +24,13 @@ export class UserService {
     try {
       const { email, password, confirmPassword, nickname } = signupData;
       const findUser = await this.userRepository.findOne({
-        where: { email },
+        where: { nickname },
       });
       if (password !== confirmPassword)
         throw new ConflictException('패스워드가 일치하지않습니다.');
-      if (nickname === findUser.nickname)
+      if (findUser && nickname === findUser.nickname) {
         throw new ConflictException('이미 존재하는 닉네임입니다.');
+      }
       const hashedPassword = await bcrypt.hash(signupData.password, 12);
       const madeUser = await this.userRepository.create({
         email: email,
@@ -37,7 +38,7 @@ export class UserService {
         password: hashedPassword,
       });
       await this.userRepository.save(madeUser);
-      return '회원가입에 성공하였습니다.';
+      return [madeUser, '회원가입에 성공하였습니다.'];
     } catch (error) {
       console.log(error.message);
       throw new BadRequestException(error.message);


### PR DESCRIPTION
nickname이 제대로 들어오는 상황에도 nickname이 존재하지 않는다는 에러가 발생함.

findOne으로 nickname에 대한 값이 db에 있다면
nickname체크를 해주도록 하였음.

      const findUser = await this.userRepository.findOne({
        where: { nickname },
      });
      if (password !== confirmPassword)
        throw new ConflictException('패스워드가 일치하지않습니다.');
      if (findUser && nickname === findUser.nickname) {
        throw new ConflictException('이미 존재하는 닉네임입니다.');
      }